### PR TITLE
Form reset bug

### DIFF
--- a/packages/frontpage/app/(app)/post/new/_client.tsx
+++ b/packages/frontpage/app/(app)/post/new/_client.tsx
@@ -10,9 +10,15 @@ import { Alert, AlertDescription, AlertTitle } from "@/lib/components/ui/alert";
 export function NewPostForm() {
   const [state, action] = useActionState(newPostAction, null);
   const id = useId();
-
   return (
-    <form action={action} className="flex flex-col gap-3">
+    <form
+      action={action}
+      onSubmit={(e) => {
+        e.preventDefault();
+        action(new FormData(e.currentTarget));
+      }}
+      className="flex flex-col gap-3"
+    >
       <div>
         <Label htmlFor={`${id}-title`}>Title</Label>
         <Input name="title" id={`${id}-title`} />


### PR DESCRIPTION
fixes the bug where you submit a form with errors and its clears form data

Not sure if you need the `action={action}` prop now that the `onSubmit` calls `action()` (it does seem to work without) but have left it in there for now