### PR TITLE
Don't swallow unknown collections

### DIFF
--- a/packages/frontpage/lib/auth.ts
+++ b/packages/frontpage/lib/auth.ts
@@ -55,7 +55,6 @@ const auth = NextAuth({
   callbacks: {
     jwt: async ({ token, user }) => {
       if (user) {
-        console.log(user);
         const refreshJwt = (user as any).refreshJwt;
         const accessJwt = (user as any).accessJwt;
         const refresh = decodeJwt(refreshJwt);

--- a/packages/frontpage/lib/data.ts
+++ b/packages/frontpage/lib/data.ts
@@ -345,7 +345,6 @@ type CommentInput = {
 export async function createComment({ subjectRkey, content }: CommentInput) {
   await ensureIsInBeta();
   const user = await ensureUser();
-  console.log(subjectRkey);
   const post = await getPost(subjectRkey);
 
   if (!post) {


### PR DESCRIPTION
If drainpipe sends us a record that we don't expect, we should throw to signal that we weren't expecting it. Otherwise drainpipe won't record it to the dlq.