### PR TITLE
Save source msg to dlq

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,8 @@
         }
       },
       "args": [],
-      "cwd": "${workspaceFolder}/packages-rs/drainpipe"
+      "cwd": "${workspaceFolder}/packages-rs/drainpipe",
+      "envFile": "${workspaceFolder}/packages-rs/drainpipe/.env" 
     },
     {
       "type": "lldb",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "debug-ignore"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe7ed1d93f4553003e20b629abe9085e1e81b1429520f897f8f8860bc6dfc21"
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,6 +387,7 @@ dependencies = [
  "chrono",
  "ciborium",
  "cid",
+ "debug-ignore",
  "diesel",
  "diesel_migrations",
  "dotenv-flow",

--- a/packages-rs/drainpipe/Cargo.toml
+++ b/packages-rs/drainpipe/Cargo.toml
@@ -8,6 +8,7 @@ anyhow = "1.0.86"
 chrono = { version = "0.4.38", features = ["serde"] }
 ciborium = "0.2.2"
 cid = { version = "0.11.1", features = ["serde-codec"] }
+debug-ignore = "1.0.5"
 diesel = { version = "2.2.0", features = ["sqlite"] }
 diesel_migrations = "2.2.0"
 dotenv-flow = "0.16.2"

--- a/packages-rs/drainpipe/diesel.toml
+++ b/packages-rs/drainpipe/diesel.toml
@@ -6,4 +6,4 @@ file = "src/schema.rs"
 custom_type_derives = ["diesel::query_builder::QueryId", "Clone"]
 
 [migrations_directory]
-dir = "/home/tom/code/unravel/packages-rs/drainpipe/migrations"
+dir = "./migrations"

--- a/packages-rs/drainpipe/migrations/2024-06-12-232142_create_db/up.sql
+++ b/packages-rs/drainpipe/migrations/2024-06-12-232142_create_db/up.sql
@@ -5,9 +5,7 @@ CREATE TABLE IF NOT EXISTS drainpipe(
 
 CREATE TABLE IF NOT EXISTS dead_letter_queue(
   seq bigint NOT NULL,
-  err_kind int NOT NULL,
-  err_msg text NOT NULL,
-  source text NOT NULL
+  msg text NOT NULL
 );
 
 INSERT INTO drainpipe(seq)

--- a/packages-rs/drainpipe/migrations/2024-06-12-232142_create_db/up.sql
+++ b/packages-rs/drainpipe/migrations/2024-06-12-232142_create_db/up.sql
@@ -5,7 +5,7 @@ CREATE TABLE IF NOT EXISTS drainpipe(
 
 CREATE TABLE IF NOT EXISTS dead_letter_queue(
   seq bigint NOT NULL,
-  err_kind int NOT NULL,
+  err_kind smallint NOT NULL,
   err_msg text NOT NULL,
   source text NOT NULL
 );

--- a/packages-rs/drainpipe/migrations/2024-06-12-232142_create_db/up.sql
+++ b/packages-rs/drainpipe/migrations/2024-06-12-232142_create_db/up.sql
@@ -5,7 +5,9 @@ CREATE TABLE IF NOT EXISTS drainpipe(
 
 CREATE TABLE IF NOT EXISTS dead_letter_queue(
   seq bigint NOT NULL,
-  msg text NOT NULL
+  err_kind int NOT NULL,
+  err_msg text NOT NULL,
+  source text NOT NULL
 );
 
 INSERT INTO drainpipe(seq)

--- a/packages-rs/drainpipe/migrations/2024-06-12-232142_create_db/up.sql
+++ b/packages-rs/drainpipe/migrations/2024-06-12-232142_create_db/up.sql
@@ -5,7 +5,7 @@ CREATE TABLE IF NOT EXISTS drainpipe(
 
 CREATE TABLE IF NOT EXISTS dead_letter_queue(
   seq bigint NOT NULL,
-  err_kind smallint NOT NULL,
+  err_kind int NOT NULL,
   err_msg text NOT NULL,
   source text NOT NULL
 );

--- a/packages-rs/drainpipe/migrations/2024-06-19-154133_save_source_msg_to_dlq/down.sql
+++ b/packages-rs/drainpipe/migrations/2024-06-19-154133_save_source_msg_to_dlq/down.sql
@@ -1,0 +1,7 @@
+ALTER TABLE dead_letter_queue RENAME COLUMN err_msg TO msg;
+
+ALTER TABLE dead_letter_queue
+  DROP COLUMN source;
+
+ALTER TABLE dead_letter_queue
+  DROP COLUMN err_kind;

--- a/packages-rs/drainpipe/migrations/2024-06-19-154133_save_source_msg_to_dlq/up.sql
+++ b/packages-rs/drainpipe/migrations/2024-06-19-154133_save_source_msg_to_dlq/up.sql
@@ -1,7 +1,7 @@
 ALTER TABLE dead_letter_queue RENAME COLUMN msg TO err_msg;
 
 ALTER TABLE dead_letter_queue
-  ADD COLUMN source text;
+  ADD COLUMN source blob;
 
 ALTER TABLE dead_letter_queue
   ADD COLUMN err_kind int;

--- a/packages-rs/drainpipe/migrations/2024-06-19-154133_save_source_msg_to_dlq/up.sql
+++ b/packages-rs/drainpipe/migrations/2024-06-19-154133_save_source_msg_to_dlq/up.sql
@@ -1,0 +1,7 @@
+ALTER TABLE dead_letter_queue RENAME COLUMN msg TO err_msg;
+
+ALTER TABLE dead_letter_queue
+  ADD COLUMN source text;
+
+ALTER TABLE dead_letter_queue
+  ADD COLUMN err_kind int;

--- a/packages-rs/drainpipe/src/db.rs
+++ b/packages-rs/drainpipe/src/db.rs
@@ -62,7 +62,7 @@ pub struct DrainpipeMeta {
 #[diesel(check_for_backend(diesel::sqlite::Sqlite))]
 pub struct DeadLetter {
     pub seq: i64,
-    pub err_kind: ProcessErrorKind,
+    pub err_kind: Option<ProcessErrorKind>,
     pub err_msg: String,
-    pub source: Source,
+    pub source: Option<Source>,
 }

--- a/packages-rs/drainpipe/src/db.rs
+++ b/packages-rs/drainpipe/src/db.rs
@@ -38,7 +38,7 @@ pub fn record_dead_letter(
 
     diesel::insert_into(dead_letter_queue)
         .values((
-            err_kind.eq(kind as i32),
+            err_kind.eq(kind),
             err_msg.eq(&new_msg),
             seq.eq(&new_seq),
             source.eq(&message),
@@ -68,7 +68,7 @@ pub struct DrainpipeMeta {
 #[diesel(check_for_backend(diesel::sqlite::Sqlite))]
 pub struct DeadLetter {
     pub seq: i64,
-    pub err_kind: i32,
+    pub err_kind: ProcessErrorKind,
     pub err_msg: String,
     pub source: String,
 }

--- a/packages-rs/drainpipe/src/db.rs
+++ b/packages-rs/drainpipe/src/db.rs
@@ -2,7 +2,7 @@ use diesel::prelude::*;
 use diesel::sqlite::SqliteConnection;
 use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
 
-use crate::ProcessErrorKind;
+use crate::{ProcessErrorKind, Source};
 
 pub fn db_connect(database_url: &String) -> anyhow::Result<SqliteConnection> {
     SqliteConnection::establish(&database_url).map_err(Into::into)
@@ -32,7 +32,7 @@ pub fn record_dead_letter(
     kind: ProcessErrorKind,
     new_msg: &str,
     new_seq: i64,
-    message: &str,
+    message: Source,
 ) -> anyhow::Result<()> {
     use crate::schema::dead_letter_queue::dsl::*;
 
@@ -70,5 +70,5 @@ pub struct DeadLetter {
     pub seq: i64,
     pub err_kind: ProcessErrorKind,
     pub err_msg: String,
-    pub source: String,
+    pub source: Source,
 }

--- a/packages-rs/drainpipe/src/db.rs
+++ b/packages-rs/drainpipe/src/db.rs
@@ -1,8 +1,9 @@
 use diesel::prelude::*;
 use diesel::sqlite::SqliteConnection;
 use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
+use std::ops::Deref;
 
-use crate::{ProcessError, ProcessErrorKind, Source};
+use crate::{ProcessError, ProcessErrorKind};
 
 pub fn db_connect(database_url: &String) -> anyhow::Result<SqliteConnection> {
     SqliteConnection::establish(&database_url).map_err(Into::into)
@@ -35,7 +36,7 @@ pub fn record_dead_letter(conn: &mut SqliteConnection, e: &ProcessError) -> anyh
             err_kind.eq(&e.kind),
             err_msg.eq(&e.inner.to_string()),
             seq.eq(&e.seq),
-            source.eq(&e.source),
+            source.eq(&e.source.deref()),
         ))
         .execute(conn)?;
 
@@ -64,5 +65,5 @@ pub struct DeadLetter {
     pub seq: i64,
     pub err_kind: Option<ProcessErrorKind>,
     pub err_msg: String,
-    pub source: Option<Source>,
+    pub source: Option<Vec<u8>>,
 }

--- a/packages-rs/drainpipe/src/main.rs
+++ b/packages-rs/drainpipe/src/main.rs
@@ -228,7 +228,7 @@ async fn main() {
                         Err(error) => {
                             eprintln!("Error processing message: {error:?}");
                             record_dead_letter(&mut ctx.db_connection, &error)
-                                .map_err(|_| eprintln!("Failed to record dead letter"))
+                                .map_err(|e| eprintln!("Failed to record dead letter {e:?}"))
                                 .ok();
                         }
                     }

--- a/packages-rs/drainpipe/src/schema.rs
+++ b/packages-rs/drainpipe/src/schema.rs
@@ -3,8 +3,10 @@
 diesel::table! {
     dead_letter_queue (rowid) {
         rowid -> Integer,
+        err_kind -> Integer,
+        err_msg -> Text,
         seq -> BigInt,
-        msg -> Text,
+        source -> Text,
     }
 }
 
@@ -15,7 +17,4 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    dead_letter_queue,
-    drainpipe,
-);
+diesel::allow_tables_to_appear_in_same_query!(dead_letter_queue, drainpipe,);

--- a/packages-rs/drainpipe/src/schema.rs
+++ b/packages-rs/drainpipe/src/schema.rs
@@ -4,9 +4,9 @@ diesel::table! {
     dead_letter_queue (rowid) {
         rowid -> Integer,
         seq -> BigInt,
-        err_kind -> Integer,
+        err_kind -> Nullable<Integer>,
         err_msg -> Text,
-        source -> Text,
+        source -> Nullable<Text>,
     }
 }
 
@@ -17,7 +17,4 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    dead_letter_queue,
-    drainpipe,
-);
+diesel::allow_tables_to_appear_in_same_query!(dead_letter_queue, drainpipe,);

--- a/packages-rs/drainpipe/src/schema.rs
+++ b/packages-rs/drainpipe/src/schema.rs
@@ -4,9 +4,9 @@ diesel::table! {
     dead_letter_queue (rowid) {
         rowid -> Integer,
         seq -> BigInt,
-        err_kind -> Nullable<Integer>,
         err_msg -> Text,
-        source -> Nullable<Text>,
+        source -> Nullable<Binary>,
+        err_kind -> Nullable<Integer>,
     }
 }
 
@@ -17,4 +17,7 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(dead_letter_queue, drainpipe,);
+diesel::allow_tables_to_appear_in_same_query!(
+    dead_letter_queue,
+    drainpipe,
+);

--- a/packages-rs/drainpipe/src/schema.rs
+++ b/packages-rs/drainpipe/src/schema.rs
@@ -3,9 +3,9 @@
 diesel::table! {
     dead_letter_queue (rowid) {
         rowid -> Integer,
+        seq -> BigInt,
         err_kind -> Integer,
         err_msg -> Text,
-        seq -> BigInt,
         source -> Text,
     }
 }
@@ -17,4 +17,7 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(dead_letter_queue, drainpipe,);
+diesel::allow_tables_to_appear_in_same_query!(
+    dead_letter_queue,
+    drainpipe,
+);


### PR DESCRIPTION
I noticed a TODO on line 149 of `main.rs`:

```
// TODO: Would be good to include the actual dropped message here but my rust skill issues are preventing me from doing so
```

So I thought I'd give it a try :) my rust skills are fairly rudimentary also, but this currently compiles, and I'm going to poke around and do some testing now.

## Changes

- Added two new columns to the `DeadLetter` table
    - `err_kind: Integer` 0 for a `DecodeError`, 1 for a `ProcessError`, since we weren't saving any of the former to the db.
    - `source: Text`, which is a UTF-8 encoded string from the `Vec<u8>` message that caused the error.
- Previously only `ProcessError`s were being saved, so I adjusted that to save `DecodeErrors` as well (using `-1` for the `seq`)
- refactored the `ProcessError` struct - since they were pretty similar enums, I adjusted it to be a `struct` with a `ProcessErrorKind` enum to differentiate between the two kinds.  this way, we're able to save the one struct to the dead letter, rather than needing to handle both enum types.

This was just an attempt to tackle that TODO I noticed in the code, so please call out anything that could be adjusted, as you see fit!