### PR TITLE
Add break point styles to post card

### DIFF
--- a/packages/frontpage/app/(app)/_components/post-card.tsx
+++ b/packages/frontpage/app/(app)/_components/post-card.tsx
@@ -33,7 +33,7 @@ export async function PostCard({
 
   return (
     // TODO: Make article route to postHref via onClick on card except innser links or buttons
-    <article className="p-3.5 flex items-center gap-4 bg-white dark:bg-gray-950 shadow-md rounded-lg">
+    <article className="flex items-center gap-4 shadow-sm rounded-lg p-4">
       <div className="flex flex-col items-center">
         <Button
           variant="ghost"
@@ -46,7 +46,7 @@ export async function PostCard({
         <span className="font-medium">{votes}</span>
       </div>
       <div className="w-full">
-        <h2 className="font-bold mb-1 sm:text-xl">
+        <h2 className="mb-1 text-xl">
           <a
             href={url}
             className="hover:underline flex flex-wrap items-center gap-x-2"

--- a/packages/frontpage/app/(app)/_components/post-card.tsx
+++ b/packages/frontpage/app/(app)/_components/post-card.tsx
@@ -33,8 +33,8 @@ export async function PostCard({
 
   return (
     // TODO: Make article route to postHref via onClick on card except innser links or buttons
-    <article className="relative flex items-center gap-4 bg-white dark:bg-gray-950 rounded-lg shadow-sm p-4">
-      <div className="flex flex-col items-center gap-2">
+    <article className="pb-6 flex items-center gap-4 bg-white dark:bg-gray-950 border-b border-gray-300">
+      <div className="flex flex-col items-center">
         <Button
           variant="ghost"
           size="icon"
@@ -45,22 +45,32 @@ export async function PostCard({
         </Button>
         <span className="font-medium">{votes}</span>
       </div>
-      <div className="flex-1">
-        <h2 className="text-xl font-medium mb-1">
+      <div className="w-full">
+        <h2 className="font-bold mb-1 sm:text-xl">
           <a href={url} className="hover:underline">
             {title}
           </a>
         </h2>
-        <div className="text-gray-500 dark:text-gray-400 flex items-center gap-2">
-          <span>{new URL(url).host}</span>
-          <span aria-hidden>•</span>
-          <span>by {handle}</span>
-          <span aria-hidden>•</span>
-          <TimeAgo createdAt={createdAt} side="bottom" />
-          <span aria-hidden>•</span>
-          <Link href={postHref} className="hover:underline">
-            {commentCount} comments
-          </Link>
+        <div className="flex flex-col gap-2 md:flex-row md:gap-4 text-gray-500 dark:text-gray-400">
+          <div className="flex flex-col gap-2 sm:flex-row sm:justify-between md:gap-4">
+            <span>{new URL(url).host}</span>
+            <div className="flex gap-2">
+              <span aria-hidden>•</span>
+              <span>by {handle}</span>
+            </div>
+          </div>
+          <div className="flex items-center justify-between gap-2 md:gap-4">
+            <div className="flex gap-2">
+              <span aria-hidden>•</span>
+              <TimeAgo createdAt={createdAt} side="bottom" />
+            </div>
+            <div className="flex gap-2">
+              <span aria-hidden>•</span>
+              <Link href={postHref} className="hover:underline">
+                {commentCount} comments
+              </Link>
+            </div>
+          </div>
         </div>
       </div>
     </article>

--- a/packages/frontpage/app/(app)/_components/post-card.tsx
+++ b/packages/frontpage/app/(app)/_components/post-card.tsx
@@ -33,7 +33,7 @@ export async function PostCard({
 
   return (
     // TODO: Make article route to postHref via onClick on card except innser links or buttons
-    <article className="pb-6 flex items-center gap-4 bg-white dark:bg-gray-950 border-b border-gray-300">
+    <article className="p-3.5 flex items-center gap-4 bg-white dark:bg-gray-950 shadow-md rounded-lg">
       <div className="flex flex-col items-center">
         <Button
           variant="ghost"
@@ -47,19 +47,24 @@ export async function PostCard({
       </div>
       <div className="w-full">
         <h2 className="font-bold mb-1 sm:text-xl">
-          <a href={url} className="hover:underline">
-            {title}
+          <a
+            href={url}
+            className="hover:underline flex flex-wrap items-center gap-x-2"
+          >
+            {title}{" "}
+            <span className="text-gray-500 dark:text-gray-400 font-normal text-sm md:text-base">
+              ({new URL(url).host})
+            </span>
           </a>
         </h2>
-        <div className="flex flex-col gap-2 md:flex-row md:gap-4 text-gray-500 dark:text-gray-400">
-          <div className="flex flex-col gap-2 sm:flex-row sm:justify-between md:gap-4">
-            <span>{new URL(url).host}</span>
+        <div className="flex flex-wrap text-gray-500 dark:text-gray-400 sm:gap-4">
+          <div className="flex gap-2 flex-wrap md:flex-nowrap">
             <div className="flex gap-2">
               <span aria-hidden>•</span>
               <span>by {handle}</span>
             </div>
           </div>
-          <div className="flex items-center justify-between gap-2 md:gap-4">
+          <div className="w-full flex items-center justify-between gap-2 md:gap-4 sm:w-auto">
             <div className="flex gap-2">
               <span aria-hidden>•</span>
               <TimeAgo createdAt={createdAt} side="bottom" />


### PR DESCRIPTION
A few style changes just to make the post card a little easier on the eye. Screenshots below show the different views for mobile/tablet and desktop.

![Screenshot from 2024-06-17 17-24-32](https://github.com/likeandscribe/unravel/assets/42817702/82df08c9-47ae-4242-95fb-3857c52d8ce3)
![Screenshot from 2024-06-17 17-24-46](https://github.com/likeandscribe/unravel/assets/42817702/9326cc73-239b-40a1-8927-ca7610393762)
![Screenshot from 2024-06-17 17-24-57](https://github.com/likeandscribe/unravel/assets/42817702/54a47df5-5788-4f8e-9e71-9271614ad0f6)
