### PR TITLE
Fix invalid vote subject URI

### DIFF
--- a/packages/frontpage/app/(app)/_components/post-card.tsx
+++ b/packages/frontpage/app/(app)/_components/post-card.tsx
@@ -46,6 +46,7 @@ export async function PostCard({
             "use server";
             await ensureUser();
             await createVote({
+              subjectAuthorDid: author,
               subjectCid: cid,
               subjectRkey: rkey,
               subjectCollection: PostCollection,

--- a/packages/frontpage/app/(app)/post/[rkey]/_actions.tsx
+++ b/packages/frontpage/app/(app)/post/[rkey]/_actions.tsx
@@ -71,9 +71,14 @@ export async function deleteCommentAction(rkey: string) {
   await deleteComment(rkey);
 }
 
-export async function commentVoteAction(input: { cid: string; rkey: string }) {
+export async function commentVoteAction(input: {
+  cid: string;
+  rkey: string;
+  authorDid: string;
+}) {
   await ensureUser();
   await createVote({
+    subjectAuthorDid: input.authorDid,
     subjectCid: input.cid,
     subjectRkey: input.rkey,
     subjectCollection: CommentCollection,

--- a/packages/frontpage/app/(app)/post/[rkey]/_comment.tsx
+++ b/packages/frontpage/app/(app)/post/[rkey]/_comment.tsx
@@ -52,7 +52,8 @@ export type CommentProps = VariantProps<typeof commentVariants> & {
   cid: string;
   id: number;
   postRkey: string;
-  author: string;
+  handle: string;
+  authorDid: string;
   comment: string;
   createdAt: Date;
   initialVoteState: VoteButtonState;
@@ -64,7 +65,8 @@ export function CommentClient({
   rkey,
   cid,
   postRkey,
-  author,
+  authorDid,
+  handle,
   comment,
   level,
   createdAt,
@@ -79,7 +81,7 @@ export function CommentClient({
     <article className={commentVariants({ level })}>
       <div className="grid gap-2 flex-1 p-1" tabIndex={0} ref={commentRef}>
         <div className="flex items-center gap-2">
-          <div className="font-medium">{author}</div>
+          <div className="font-medium">{handle}</div>
           <div className="text-gray-500 text-xs dark:text-gray-400">
             <TimeAgo createdAt={createdAt} side="bottom" />
           </div>
@@ -92,6 +94,7 @@ export function CommentClient({
             <VoteButton
               initialState={initialVoteState}
               voteAction={commentVoteAction.bind(null, {
+                authorDid,
                 cid,
                 rkey,
               })}

--- a/packages/frontpage/app/(app)/post/[rkey]/_commentServer.tsx
+++ b/packages/frontpage/app/(app)/post/[rkey]/_commentServer.tsx
@@ -4,7 +4,7 @@ import { getCommentsForPost } from "@/lib/data/db/comment";
 
 type ServerCommentProps = Omit<
   CommentProps,
-  "voteAction" | "unvoteAction" | "initialVoteState" | "hasAuthored"
+  "voteAction" | "unvoteAction" | "initialVoteState" | "hasAuthored" | "handle"
 > & {
   cid: string;
   isUpvoted: boolean;
@@ -12,27 +12,28 @@ type ServerCommentProps = Omit<
 };
 
 export async function Comment({
-  author,
+  authorDid,
   isUpvoted,
   childComments,
   ...props
 }: ServerCommentProps) {
-  const plc = await getPlcDoc(author);
+  const plc = await getPlcDoc(authorDid);
   const handle = plc.alsoKnownAs
     .find((handle) => handle.startsWith("at://"))
     ?.replace("at://", "");
 
   const user = await getUser();
-  const hasAuthored = user?.did === author;
+  const hasAuthored = user?.did === authorDid;
 
   return (
     <>
       <CommentClient
         {...props}
-        author={handle ?? ""}
+        handle={handle ?? ""}
         hasAuthored={hasAuthored}
+        authorDid={authorDid}
         initialVoteState={
-          (await getUser())?.did === author
+          (await getUser())?.did === authorDid
             ? "authored"
             : isUpvoted
               ? "voted"
@@ -46,7 +47,7 @@ export async function Comment({
           cid={comment.cid}
           rkey={comment.rkey}
           postRkey={props.postRkey}
-          author={comment.authorDid}
+          authorDid={comment.authorDid}
           comment={comment.body}
           createdAt={comment.createdAt}
           childComments={comment.children}

--- a/packages/frontpage/app/(app)/post/[rkey]/page.tsx
+++ b/packages/frontpage/app/(app)/post/[rkey]/page.tsx
@@ -60,7 +60,7 @@ export default async function Item({ params }: { params: Params }) {
               cid={comment.cid}
               rkey={comment.rkey}
               postRkey={post.rkey}
-              author={comment.authorDid}
+              authorDid={comment.authorDid}
               createdAt={comment.createdAt}
               id={comment.id}
               comment={comment.body}

--- a/packages/frontpage/lib/data/atproto/vote.ts
+++ b/packages/frontpage/lib/data/atproto/vote.ts
@@ -26,16 +26,18 @@ type VoteInput = {
   subjectRkey: string;
   subjectCid: string;
   subjectCollection: string;
+  subjectAuthorDid: string;
 };
 
 export async function createVote({
   subjectRkey,
   subjectCid,
   subjectCollection,
+  subjectAuthorDid,
 }: VoteInput) {
-  const user = await ensureUser();
+  await ensureUser();
   await ensureIsInBeta();
-  const uri = `at://${user.did}/${subjectCollection}/${subjectRkey}`;
+  const uri = `at://${subjectAuthorDid}/${subjectCollection}/${subjectRkey}`;
 
   const record = {
     createdAt: new Date().toISOString(),


### PR DESCRIPTION
There was a bug where we were always passing the current user did into the uri of the vote subject. Instead we needed to pass the relevant comment or post author did.