### PR TITLE
Remove "learn more" beta button when in the beta

### DIFF
--- a/packages/frontpage/app/(app)/layout.tsx
+++ b/packages/frontpage/app/(app)/layout.tsx
@@ -50,13 +50,16 @@ export default async function Layout({
               <>You&apos;re not currently part of the beta</>
             )}
           </span>
-          <Button
-            asChild
-            variant="ghost"
-            className="text-indigo-600 dark:text-indigo-400"
-          >
-            <Link href="/invite-only">Learn more</Link>
-          </Button>
+
+          {!isInBeta && (
+            <Button
+              asChild
+              variant="ghost"
+              className="text-indigo-600 dark:text-indigo-400"
+            >
+              <Link href="/invite-only">Learn more</Link>
+            </Button>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
If the user is in the beta, we shouldn't need to show the "Learn More" button for the beta that recommends DMing us for the beta. This also makes the note not break-line.