### PR TITLE
chore: updated unravel to frontpage for bug report link

### DIFF
--- a/packages/frontpage/app/(app)/layout.tsx
+++ b/packages/frontpage/app/(app)/layout.tsx
@@ -54,9 +54,8 @@ export default async function Layout({
                   href={`https://bsky.app/profile/${FRONTPAGE_ATPROTO_HANDLE}`}
                   className="font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
                 >
-                  @unravel.fyi <OpenInNewWindowIcon className="inline" />
+                  @frontpage.fyi <OpenInNewWindowIcon className="inline" />
                 </a>
-                !
               </>
             ) : (
               <>You&apos;re not currently part of the beta</>


### PR DESCRIPTION
Updated this to align with now being frontpage.fyi on Bluesky and I also removed the `!` as it feels weird being next to the new page icon imo.

![image](https://github.com/user-attachments/assets/3da7154a-1a92-4389-86f9-3f06282329f0)
