### PR TITLE
atproto-browser: Support BlueSky post URIs

### DIFF
--- a/packages/atproto-browser/app/actions.ts
+++ b/packages/atproto-browser/app/actions.ts
@@ -5,6 +5,14 @@ import { AtUri } from "@atproto/syntax";
 import { redirect } from "next/navigation";
 
 export async function navigateUri(_state: unknown, formData: FormData) {
-  const uri = new AtUri(formData.get("uri") as string);
-  redirect(getAtUriPath(uri));
+  let uri = formData.get("uri") as string;
+
+  if (uri.startsWith("https://")) {
+    const authority = uri.split("/")[4];
+    const rkey = uri.split("/")[6];
+    uri = `at://${authority}/app.bsky.feed.post/${rkey}`;
+  }
+
+  const atUri = new AtUri(uri);
+  redirect(getAtUriPath(atUri));
 }

--- a/packages/atproto-browser/app/page.tsx
+++ b/packages/atproto-browser/app/page.tsx
@@ -12,12 +12,15 @@ const EXAMPLE_PATH = "tom-sherman.com/app.bsky.feed.like/3kyutnrmg3s2r";
 export default function Home() {
   return (
     <main>
-      <h1>Enter an AT uri:</h1>
+      <h1>Enter an AT uri or BlueSky post uri:</h1>
       <div style={{ maxWidth: "450px" }}>
         <AtUriForm />
       </div>
       <p>
-        eg. <Link href={`/at/${EXAMPLE_PATH}`}>at://{EXAMPLE_PATH}</Link>
+        eg. <Link href={`/at/${EXAMPLE_PATH}`}>at://{EXAMPLE_PATH}</Link> or{" "}
+        <Link href={`/at/danabra.mov/app.bsky.feed.post/3kyt2aywc2k2d`}>
+          https://bsky.app/profile/danabra.mov/post/3kyt2aywc2k2d
+        </Link>
       </p>
 
       <footer>


### PR DESCRIPTION
Hello! Thanks for making atproto-browser, it's been a fun tool for me to look at the videos the BlueSky team has been uploading. :)

I've been manually converting BlueSky post URIs (e.g. https://bsky.app/profile/danabra.mov/post/3kyt2aywc2k2d) into the equivalent AT URIs (e.g. at://danabra.mov/app.bsky.feed.post/3kyt2aywc2k2d), which has gotten a bit tedious.

This PR adds some string manipulation to the form to convert BlueSky post URIs into their corresponding AT URIs. It is a bit opinionated by giving BlueSky special treatment, so I totally understand if you don't want to accept the PR. I'd argue the usability benefits are worth it (by making it easier for folks to "see under the hood" and understand that BlueSky is just an AppView over atproto).