### PR TITLE
Preserve paragraphs in comments

### DIFF
--- a/packages/frontpage/app/(app)/post/[postAuthor]/[postRkey]/_lib/comment.tsx
+++ b/packages/frontpage/app/(app)/post/[postAuthor]/[postRkey]/_lib/comment.tsx
@@ -120,9 +120,14 @@ async function LiveComment({
             <TimeAgo createdAt={comment.createdAt} side="bottom" />
           </Link>
         </div>
-        {comment.body
-          ?.split("\n")
-          .map((line, index) => <p key={index}>{line}</p>)}
+        {comment.body?.split("\n").map((line, index) => (
+          <p
+            // eslint-disable-next-line react/no-array-index-key
+            key={index}
+          >
+            {line}
+          </p>
+        ))}
       </CommentClientWrapperWithToolbar>
 
       {comment.children?.map((comment) => (

--- a/packages/frontpage/app/(app)/post/[postAuthor]/[postRkey]/_lib/comment.tsx
+++ b/packages/frontpage/app/(app)/post/[postAuthor]/[postRkey]/_lib/comment.tsx
@@ -120,7 +120,9 @@ async function LiveComment({
             <TimeAgo createdAt={comment.createdAt} side="bottom" />
           </Link>
         </div>
-        <p>{comment.body}</p>
+        {comment.body
+          ?.split("\n")
+          .map((line, index) => <p key={index}>{line}</p>)}
       </CommentClientWrapperWithToolbar>
 
       {comment.children?.map((comment) => (

--- a/packages/frontpage/app/(app)/post/[postAuthor]/[postRkey]/_lib/comment.tsx
+++ b/packages/frontpage/app/(app)/post/[postAuthor]/[postRkey]/_lib/comment.tsx
@@ -120,14 +120,7 @@ async function LiveComment({
             <TimeAgo createdAt={comment.createdAt} side="bottom" />
           </Link>
         </div>
-        {comment.body?.split("\n").map((line, index) => (
-          <p
-            // eslint-disable-next-line react/no-array-index-key
-            key={index}
-          >
-            {line}
-          </p>
-        ))}
+        <p className="whitespace-pre-wrap">{comment.body}</p>
       </CommentClientWrapperWithToolbar>
 
       {comment.children?.map((comment) => (

--- a/packages/frontpage/lib/data/atproto/comment.ts
+++ b/packages/frontpage/lib/data/atproto/comment.ts
@@ -36,8 +36,10 @@ type CommentInput = {
 
 export async function createComment({ parent, post, content }: CommentInput) {
   await ensureIsInBeta();
+  // Collapse newlines into a single \n\n and trim whitespace
+  const sanitizedContent = content.replace(/\n\n+/g, "\n\n").trim();
   const record = {
-    content,
+    content: sanitizedContent,
     parent: parent
       ? {
           cid: parent.cid,


### PR DESCRIPTION
We're saving comments with newlines in the db but just discarding them by rendering the comment to a single text node.

This is mostly just a quick stop-gap fix until we get proper rich text editing.

https://frontpage-git-preserve-paragraphs-in-comments-likeandscribe.vercel.app/post/tom-sherman.com/3kuuvmpeytj2q/tom-sherman.com/3l4xqnajkkk2p

https://frontpage-git-preserve-paragraphs-in-comments-likeandscribe.vercel.app/post/purlane.ink/3l4xe52w6zw2n/purlane.ink/3l4xfw6a7z32z