### PR TITLE
fix: reduced avatar size and relocated theme toggle

### DIFF
--- a/packages/frontpage/app/(app)/layout.tsx
+++ b/packages/frontpage/app/(app)/layout.tsx
@@ -48,6 +48,7 @@ export default async function Layout({
               <Link href="/post/new">New</Link>
             </Button>
           ) : null}
+          <ThemeToggle />
           <Suspense>
             <LoginOrLogout />
           </Suspense>
@@ -66,9 +67,6 @@ export default async function Layout({
             @unravel.fyi <OpenInNewWindowIcon className="inline" />
           </a>
         </p>
-        <div>
-          <ThemeToggle />
-        </div>
       </footer>
     </div>
   );
@@ -132,5 +130,9 @@ async function LoginOrLogout() {
     );
   }
 
-  return <Link href="/login">Login</Link>;
+  return (
+    <Button variant="outline" asChild>
+      <Link href="/login">Login</Link>
+    </Button>
+  );
 }

--- a/packages/frontpage/lib/components/user-avatar.tsx
+++ b/packages/frontpage/lib/components/user-avatar.tsx
@@ -5,7 +5,7 @@ import { DID } from "../data/atproto/did";
 
 const userAvatarSizes = {
   small: 22,
-  smedium: 50,
+  smedium: 36,
   medium: 100,
   large: 150,
 };


### PR DESCRIPTION
This pr reduces the size of the avatar so that the height is inline with the buttons and it moves the theme toggle to the top of the page.

![Screenshot from 2024-10-16 20-40-52](https://github.com/user-attachments/assets/593a9c14-6d92-4021-8d4a-1b8c8f3080fd)

![Screenshot from 2024-10-16 20-41-25](https://github.com/user-attachments/assets/654f72d3-2937-4569-92d8-2bf810cc4f2c)
